### PR TITLE
fix: specify different name for hyper version

### DIFF
--- a/clients/rust/hyper/v1/Cargo.toml
+++ b/clients/rust/hyper/v1/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "nomad_client"
+name = "nomad_client_hyper"
 version = "1.1.4"
 authors = ["OpenAPI Generator team and contributors"]
 edition = "2018"


### PR DESCRIPTION
Rust git shenanigans

Needed for https://github.com/ForesightMiningSoftwareCorporation/mining-bot/pull/7
